### PR TITLE
Added Token support for Consul

### DIFF
--- a/backends/client.go
+++ b/backends/client.go
@@ -47,6 +47,7 @@ func New(config Config) (StoreClient, error) {
 			config.BasicAuth,
 			config.Username,
 			config.Password,
+			config.AuthToken,
 		)
 	case "etcd":
 		// Create the etcd client upfront and use it for the life of the process.

--- a/backends/consul/client.go
+++ b/backends/consul/client.go
@@ -13,7 +13,7 @@ type ConsulClient struct {
 }
 
 // NewConsulClient returns a new client to Consul for the given address
-func New(nodes []string, scheme, cert, key, caCert string, basicAuth bool, username string, password string) (*ConsulClient, error) {
+func New(nodes []string, scheme, cert, key, caCert string, basicAuth bool, username string, password string, authToken string) (*ConsulClient, error) {
 	conf := api.DefaultConfig()
 
 	conf.Scheme = scheme
@@ -35,6 +35,9 @@ func New(nodes []string, scheme, cert, key, caCert string, basicAuth bool, usern
 	}
 	if caCert != "" {
 		conf.TLSConfig.CAFile = caCert
+	}
+	if authToken != "" {
+		conf.Token = authToken
 	}
 
 	client, err := api.NewClient(conf)


### PR DESCRIPTION
Consul allows Tokens to be used when getting KVs, they are used to
provide granullar access to KVs (and improve security overall as your
Consul server will not be open to the world)